### PR TITLE
Allow altPath to be unspecified

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -209,7 +209,7 @@ status](https://help.github.com/articles/about-statuses/):
 Visit to `github.com/<user>/<repo>/settings/hooks` and create a new webhook.
 
 - Payload URL: Use your worker IP address or hostname as the hook URL,
-  `https://1.2.3.4/gohci/workerA?altPath=foo.io/x/project&superusers=user1,user2,user3`.
+  `https://1.2.3.4/gohci/workerA?altPath=foo.io/x/project&superUsers=user1,user2,user3`.
   - `altPath`: Set it when using [canonical import
     path](https://golang.org/doc/go1.4#canonicalimports). For example,
     `periph.io/x/gohci`. Leave it unspecified otherwise, which should be the

--- a/cmd/gohci-worker/server.go
+++ b/cmd/gohci-worker/server.go
@@ -273,12 +273,14 @@ func validateArgs(values url.Values) (string, []string, error) {
 	if strings.Contains(altPath, "//") || strings.Contains(altPath, "..") {
 		return "", nil, fmt.Errorf("invalid altPath %q: contains invalid characters", altPath)
 	}
-	u, err := url.Parse("https://" + altPath)
-	if err != nil {
-		return "", nil, fmt.Errorf("invalid altPath %q: %v", altPath, err)
-	}
-	if u.Scheme != "https" || u.User != nil || u.Host == "" || u.Path == "" || u.RawQuery != "" || u.Fragment != "" {
-		return "", nil, fmt.Errorf("invalid altPath %q: unexpected url format", altPath)
+	if len(altPath) > 0 {
+		u, err := url.Parse("https://" + altPath)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid altPath %q: %v", altPath, err)
+		}
+		if u.Scheme != "https" || u.User != nil || u.Host == "" || u.Path == "" || u.RawQuery != "" || u.Fragment != "" {
+			return "", nil, fmt.Errorf("invalid altPath %q: unexpected url format", altPath)
+		}
 	}
 	var superUsers []string
 	for _, v := range values["superUsers"] {


### PR DESCRIPTION
Performing the validation on an empty URL will return `unexpected url format`.

Also fix the spelling of superUsers in CONFIG.md.